### PR TITLE
[OPS-7743] add seckit config

### DIFF
--- a/config/seckit.settings.yml
+++ b/config/seckit.settings.yml
@@ -6,15 +6,15 @@ seckit_xss:
       webkit: false
     report-only: true
     default-src: ''
-    script-src: '''self'' ''unsafe-inline'' https://fonts.googleapis.com https://www.gstatic.com https://www.google.com https://www.google-analytics.com https://cdn.jsdelivr.net'
+    script-src: '''self'' ''unsafe-inline'' https://fonts.googleapis.com https://www.gstatic.com https://www.google.com https://www.google-analytics.com https://cdn.jsdelivr.net https://js-agent.newrelic.com'
     object-src: ''
-    img-src: '''self'' data:'
+    img-src: '''self'' data: https://via.placeholder.com'
     media-src: ''
     frame-src: ''
     frame-ancestors: ''
     child-src: ''
     font-src: 'https://fonts.gstatic.com'
-    connect-src: '''self'' https://www.google-analytics.com https://stats.g.doubleclick.net'
+    connect-src: '''self'' https://www.google-analytics.com https://stats.g.doubleclick.net https://gov-bam.nr-data.net https://fonts.googleapis.com https://via.placeholder.com'
     report-uri: /report-csp-violation
     upgrade-req: false
     policy-uri: ''


### PR DESCRIPTION
Adds some config picked out from the security kit logs.

(gov-bam.nr-data.net is the FedRAMP compliant url for New Relic. I checked.)