### PR TITLE
[CD-386] Color picker for CD Demo page

### DIFF
--- a/html/themes/custom/common_design_subtheme/common_design_subtheme.libraries.yml
+++ b/html/themes/custom/common_design_subtheme/common_design_subtheme.libraries.yml
@@ -7,8 +7,8 @@ global-styling:
   css:
     theme:
       css/brand.css: {}
-#   dependencies:
-#     - common_design_subtheme/custom-teaser
+  dependencies:
+    - common_design_subtheme/cds-color-picker
 
 ###
 # Define Drupal libraries for your custom components.
@@ -18,7 +18,9 @@ global-styling:
 # completely independent and style the custom content of your website, such as
 # a custom Paragraph type.
 #
-# custom-teaser:
-#   css:
-#     theme:
-#       components/custom-teaser/custom-teaser.css: {}
+cds-color-picker:
+  css:
+    component:
+      components/cds-color-picker/cds-color-picker--component.css: {}
+  js:
+    components/cds-color-picker/cds-color-picker.js: {}

--- a/html/themes/custom/common_design_subtheme/components/README.md
+++ b/html/themes/custom/common_design_subtheme/components/README.md
@@ -1,1 +1,3 @@
-Custom components can be placed in this directory
+# Custom Components
+
+Place all of your custom components in this directory. If you wish, add individual README files per-component, or use this file to list docs for all of them in one place.

--- a/html/themes/custom/common_design_subtheme/components/cds-color-picker/cds-color-picker--component.css
+++ b/html/themes/custom/common_design_subtheme/components/cds-color-picker/cds-color-picker--component.css
@@ -4,10 +4,10 @@
 .cds-color-picker {
   position: fixed;
   top: 8rem;
-  left: 2rem;
+  left: 1rem;
   z-index: 10;
-  width: 420px;
-  padding: 2rem;
+  width: auto;
+  padding: 1rem;
   margin-bottom: 2rem;
   border-radius: 4px;
   box-shadow: 2px 2px 5px #0005;
@@ -21,6 +21,10 @@
 
 .cds-color-picker__palettes {
   display: flex;
-  flex-flow: row wrap;
+  flex-flow: column nowrap;
   gap: 1rem;
+}
+
+.palette {
+  flex: 0 0 100%;
 }

--- a/html/themes/custom/common_design_subtheme/components/cds-color-picker/cds-color-picker--component.css
+++ b/html/themes/custom/common_design_subtheme/components/cds-color-picker/cds-color-picker--component.css
@@ -1,0 +1,25 @@
+/**
+ * Common Design Site color picker
+ */
+.cds-color-picker {
+  position: fixed;
+  top: 8rem;
+  left: 2rem;
+  z-index: 10;
+  width: 480px;
+  padding: 2rem;
+  margin-bottom: 2rem;
+  border-radius: 4px;
+  box-shadow: 2px 2px 5px #0005;
+  background: #fffe;
+  backdrop-filter: blur(5px);
+}
+
+.cds-color-picker .cd-title {
+  margin: 0;
+}
+
+.cds-color-picker__palettes {
+  display: flex;
+  gap: 1rem;
+}

--- a/html/themes/custom/common_design_subtheme/components/cds-color-picker/cds-color-picker--component.css
+++ b/html/themes/custom/common_design_subtheme/components/cds-color-picker/cds-color-picker--component.css
@@ -6,7 +6,7 @@
   top: 8rem;
   left: 2rem;
   z-index: 10;
-  width: 480px;
+  width: 420px;
   padding: 2rem;
   margin-bottom: 2rem;
   border-radius: 4px;
@@ -21,5 +21,6 @@
 
 .cds-color-picker__palettes {
   display: flex;
+  flex-flow: row wrap;
   gap: 1rem;
 }

--- a/html/themes/custom/common_design_subtheme/components/cds-color-picker/cds-color-picker.html.twig
+++ b/html/themes/custom/common_design_subtheme/components/cds-color-picker/cds-color-picker.html.twig
@@ -1,0 +1,40 @@
+<div class="cds-color-picker">
+  <h3 class="cd-title">CD Color Picker</h3>
+  <div class="cds-color-picker__intro">
+    <p>Choose one of the options to instantly re-color the CD Header/Footer. In time, all of the components on this page will react to the colors chosen here.</p>
+  </div>
+  <div class="cds-color-picker__palettes">
+    <div class="cdscp-palette cdscp-palette--purple"
+      data-brand-primary="#6937AC"
+      data-brand-primary-light="#B99DE0"
+      data-brand-primary-dark="#462472"
+      data-brand-highlight="#7FB92F"
+      data-brand-grey="#F1ECF9">
+      <button class="cd-button">Purple</button>
+    </div>
+    <div class="cdscp-palette cdscp-palette--turquoise"
+      data-brand-primary="#34CCC1"
+      data-brand-primary-light="#AEEAE6"
+      data-brand-primary-dark="#248F88"
+      data-brand-highlight="#DB7B18"
+      data-brand-grey="#EBFAF9">
+      <button class="cd-button">Turquoise</button>
+    </div>
+    <div class="cdscp-palette cdscp-palette--green"
+      data-brand-primary="#7FB92F"
+      data-brand-primary-light="#C6E69B"
+      data-brand-primary-dark="#557C1F"
+      data-brand-highlight="#6937AC"
+      data-brand-grey="#F4FAEB">
+      <button class="cd-button">Green</button>
+    </div>
+    <div class="cdscp-palette cdscp-palette--orange"
+      data-brand-primary="#DB7B18"
+      data-brand-primary-light="#F4C799"
+      data-brand-primary-dark="#965410"
+      data-brand-highlight="#1F69B3"
+      data-brand-grey="#FCF2E8">
+      <button class="cd-button">Orange</button>
+    </div>
+  </div>
+</div>

--- a/html/themes/custom/common_design_subtheme/components/cds-color-picker/cds-color-picker.html.twig
+++ b/html/themes/custom/common_design_subtheme/components/cds-color-picker/cds-color-picker.html.twig
@@ -15,7 +15,7 @@
     </div>
     <div class="cdscp-palette cdscp-palette--purple"
       data-brand-primary="#6937AC"
-      data-brand-primary-light="#B99DE0"
+      data-brand-primary-light="#E4D8F3"
       data-brand-primary-dark="#462472"
       data-brand-highlight="#7FB92F"
       data-brand-grey="#F1ECF9">
@@ -23,7 +23,7 @@
     </div>
     <div class="cdscp-palette cdscp-palette--turquoise"
       data-brand-primary="#34CCC1"
-      data-brand-primary-light="#AEEAE6"
+      data-brand-primary-light="#D6F5F3"
       data-brand-primary-dark="#248F88"
       data-brand-highlight="#DB7B18"
       data-brand-grey="#EBFAF9">
@@ -31,7 +31,7 @@
     </div>
     <div class="cdscp-palette cdscp-palette--green"
       data-brand-primary="#7FB92F"
-      data-brand-primary-light="#C6E69B"
+      data-brand-primary-light="#E8F5D6"
       data-brand-primary-dark="#557C1F"
       data-brand-highlight="#6937AC"
       data-brand-grey="#F4FAEB">
@@ -39,7 +39,7 @@
     </div>
     <div class="cdscp-palette cdscp-palette--orange"
       data-brand-primary="#DB7B18"
-      data-brand-primary-light="#F4C799"
+      data-brand-primary-light="#FAE6D1"
       data-brand-primary-dark="#965410"
       data-brand-highlight="#1F69B3"
       data-brand-grey="#FCF2E8">

--- a/html/themes/custom/common_design_subtheme/components/cds-color-picker/cds-color-picker.html.twig
+++ b/html/themes/custom/common_design_subtheme/components/cds-color-picker/cds-color-picker.html.twig
@@ -1,7 +1,7 @@
 <div class="cds-color-picker">
-  <h3 class="cd-title">CD Color Picker</h3>
-  <div class="cds-color-picker__intro">
-    <p>Choose one of the options to instantly re-color the CD Header/Footer. In time, all of the components on this page will react to the colors chosen here.</p>
+  <h3 class="cd-title visually-hidden">CD Color Picker</h3>
+  <div class="cds-color-picker__intro visually-hidden">
+    <p>Re-color the CD Design System.</p>
   </div>
 
   <div class="cds-color-picker__palettes">

--- a/html/themes/custom/common_design_subtheme/components/cds-color-picker/cds-color-picker.html.twig
+++ b/html/themes/custom/common_design_subtheme/components/cds-color-picker/cds-color-picker.html.twig
@@ -5,7 +5,7 @@
   </div>
 
   <div class="cds-color-picker__palettes">
-    <div class="cdscp-palette cdscp-palette--blue"
+    <div class="palette palette--blue"
       data-brand-primary="#1f69b3"
       data-brand-primary-light="#d4e5f7"
       data-brand-primary-dark="#144372"
@@ -13,7 +13,7 @@
       data-brand-grey="#e6ecf1">
       <button class="cd-button">Blue</button>
     </div>
-    <div class="cdscp-palette cdscp-palette--purple"
+    <div class="palette palette--purple"
       data-brand-primary="#6937AC"
       data-brand-primary-light="#E4D8F3"
       data-brand-primary-dark="#462472"
@@ -21,7 +21,7 @@
       data-brand-grey="#F1ECF9">
       <button class="cd-button">Purple</button>
     </div>
-    <div class="cdscp-palette cdscp-palette--turquoise"
+    <div class="palette palette--turquoise"
       data-brand-primary="#34CCC1"
       data-brand-primary-light="#D6F5F3"
       data-brand-primary-dark="#248F88"
@@ -29,7 +29,7 @@
       data-brand-grey="#EBFAF9">
       <button class="cd-button">Turquoise</button>
     </div>
-    <div class="cdscp-palette cdscp-palette--green"
+    <div class="palette palette--green"
       data-brand-primary="#7FB92F"
       data-brand-primary-light="#E8F5D6"
       data-brand-primary-dark="#557C1F"
@@ -37,7 +37,7 @@
       data-brand-grey="#F4FAEB">
       <button class="cd-button">Green</button>
     </div>
-    <div class="cdscp-palette cdscp-palette--orange"
+    <div class="palette palette--orange"
       data-brand-primary="#DB7B18"
       data-brand-primary-light="#FAE6D1"
       data-brand-primary-dark="#965410"

--- a/html/themes/custom/common_design_subtheme/components/cds-color-picker/cds-color-picker.html.twig
+++ b/html/themes/custom/common_design_subtheme/components/cds-color-picker/cds-color-picker.html.twig
@@ -3,7 +3,16 @@
   <div class="cds-color-picker__intro">
     <p>Choose one of the options to instantly re-color the CD Header/Footer. In time, all of the components on this page will react to the colors chosen here.</p>
   </div>
+
   <div class="cds-color-picker__palettes">
+    <div class="cdscp-palette cdscp-palette--blue"
+      data-brand-primary="#1f69b3"
+      data-brand-primary-light="#d4e5f7"
+      data-brand-primary-dark="#144372"
+      data-brand-highlight="#e56a54"
+      data-brand-grey="#e6ecf1">
+      <button class="cd-button">Blue</button>
+    </div>
     <div class="cdscp-palette cdscp-palette--purple"
       data-brand-primary="#6937AC"
       data-brand-primary-light="#B99DE0"

--- a/html/themes/custom/common_design_subtheme/components/cds-color-picker/cds-color-picker.js
+++ b/html/themes/custom/common_design_subtheme/components/cds-color-picker/cds-color-picker.js
@@ -10,7 +10,7 @@
   }
 
   // Find all the colors defined in markup
-  var palettes = document.querySelectorAll('.cdscp-palette');
+  var palettes = document.querySelectorAll('.palette');
 
   // Process each color palette.
   palettes.forEach((p) => {

--- a/html/themes/custom/common_design_subtheme/components/cds-color-picker/cds-color-picker.js
+++ b/html/themes/custom/common_design_subtheme/components/cds-color-picker/cds-color-picker.js
@@ -1,0 +1,26 @@
+(function iife() {
+  // Locate the required DOM elements for this component.
+  var colorPicker = document.querySelector('.cds-color-picker');
+  var root = document.documentElement;
+
+  // We only proceed if the color picker is found.
+  if (!colorPicker) {
+    console.log('cds-color-picker: could not find a color picker.');
+    return;
+  }
+
+  // Find all the colors defined in markup
+  var palettes = document.querySelectorAll('.cdscp-palette');
+
+  // Process each color palette.
+  palettes.forEach((p) => {
+    // Set up an event listener to re-color the site when clicked.
+    p.querySelector('button').addEventListener('click', (ev) => {
+      root.style.setProperty('--brand-primary', p.dataset.brandPrimary);
+      root.style.setProperty('--brand-primary--light', p.dataset.brandPrimaryLight);
+      root.style.setProperty('--brand-primary--dark', p.dataset.brandPrimaryDark);
+      root.style.setProperty('--brand-highlight', p.dataset.brandHighlight);
+      root.style.setProperty('--brand-grey', p.dataset.brandGrey);
+    });
+  })
+}());

--- a/html/themes/custom/common_design_subtheme/css/brand.css
+++ b/html/themes/custom/common_design_subtheme/css/brand.css
@@ -7,7 +7,7 @@
    * In the future the Component library will adhere to these vars as well.
    */
   --brand-primary: var(--cd-ocha-blue);
-  --brand-primary--light: var(--cd-blue--bright);
+  --brand-primary--light: var(--cd-blue--brighter);
   --brand-primary--dark: var(--cd-blue--dark);
   --brand-highlight: var(--cd-highlight-red);
   --brand-grey: var(--cd-blue-grey);

--- a/html/themes/custom/common_design_subtheme/templates/page--demo.html.twig
+++ b/html/themes/custom/common_design_subtheme/templates/page--demo.html.twig
@@ -1,0 +1,344 @@
+{#
+/**
+ * @file
+ * Theme override to display a single page.
+ *
+ * The doctype, html, head and body tags are not in this template. Instead they
+ * can be found in the html.html.twig template in this directory.
+ *
+ * Available variables:
+ *
+ * General utility variables:
+ * - base_path: The base URL path of the Drupal installation. Will usually be
+ *   "/" unless you have installed Drupal in a sub-directory.
+ * - is_front: A flag indicating if the current page is the front page.
+ * - logged_in: A flag indicating if the user is registered and signed in.
+ * - is_admin: A flag indicating if the user has permission to access
+ *   administration pages.
+ *
+ * Site identity:
+ * - front_page: The URL of the front page. Use this instead of base_path when
+ *   linking to the front page. This includes the language domain or prefix.
+ *
+ * Page content (in order of occurrence in the default page.html.twig):
+ * - node: Fully loaded node, if there is an automatically-loaded node
+ *   associated with the page and the node ID is the second argument in the
+ *   page's path (e.g. node/12345 and node/12345/revisions, but not
+ *   comment/reply/12345).
+ *
+ * Regions:
+ * - page.header: Items for the header region.
+ * - page.primary_menu: Items for the primary menu region.
+ * - page.secondary_menu: Items for the secondary menu region.
+ * - page.highlighted: Items for the highlighted content region.
+ * - page.help: Dynamic help text, mostly for admin pages.
+ * - page.content: The main content of the current page.
+ * - page.sidebar_first: Items for the first sidebar.
+ * - page.sidebar_second: Items for the second sidebar.
+ * - page.footer: Items for the footer region.
+ * - page.breadcrumb: Items for the breadcrumb region.
+ *
+ * @see template_preprocess_page()
+ * @see html.html.twig
+ */
+#}
+
+<style>
+  /* This page's styles */
+  h2.cd-styleguide,
+  h3.cd-styleguide {
+    display: block;
+    padding: 1rem;
+    background-color: var(--cd-blue-grey);
+  }
+
+  h2.cd-styleguide {
+    font-size: 2.5rem;
+    margin: 4rem 0;
+  }
+
+  h3.cd-styleguide {
+    margin: 4rem 0;
+    font-size: 2rem;
+    width: 100%;
+    border: 1px solid var(--cd-blue--bright);
+    display: flex;
+    justify-content: space-between;
+    align-content: center;
+  }
+
+  h3.cd-styleguide > a[id*="cd-"] {
+    flex: 1;
+  }
+
+  .cd-footer {
+  --cd-footer-row-number: 6;
+    grid-row: var(--cd-footer-row-number) / var(--cd-footer-row-number);
+  }
+
+</style>
+
+<div class="cd-layout-container">
+
+  {% block header %}
+    {% include '@common_design/cd/cd-header/cd-header.html.twig' %}
+  {% endblock %}
+
+  {% block hero %}
+    <div class="cd-layout-hero">
+      <h3 class="visually-hidden"><a id="cd-hero">cd-hero</a></h3>
+      {% if componentsModule %}
+        {% include '@cd-components/cd-hero/cd-hero.html.twig' %}
+      {% endif %}
+    </div>
+  {% endblock %}
+
+  {% if page.highlighted %}
+    {% block highlighted %}
+      <div class="cd-layout-highlighted cd-container">
+        {{ page.highlighted }}
+      </div>
+    {% endblock %}
+  {% endif %}
+
+  {{ page.help }}
+
+  <div class="cd-container">
+    {{ page.page_title }}
+  </div>
+
+  {# Link to skip to the main content is in html.html.twig #}
+  <main role="main" id="main-content" class="cd-container">
+
+    <div class="cd-layout-content">
+
+      <div class="cd-toc [ cd-flow ]">
+        <div class="cd-toc__title">Table of Contents</div>
+        <ol id="cd-component-toc" class="cd-toc__list">
+          <li><a href="#cd-alert">Alert</a></li>
+          <li><a href="#cd-article">Article</a></li>
+          <li><a href="#cd-author">Author</a></li>
+          <li><a href="#cd-banner">Banner</a></li>
+          <li><a href="#cd-block-title">Block Title</a></li>
+          <li><a href="#cd-bullet-list">Bullet List</a></li>
+          <li><a href="#cd-button">Buttons</a></li>
+          <li><a href="#cd-byline">Byline</a></li>
+          <li><a href="#cd-banner">Caption</a></li>
+          <li><a href="#cd-card">Card</a></li>
+          <li><a href="#cd-date">Date</a></li>
+          <li><a href="#cd-event">Event</a></li>
+          <li><a href="#cd-figure-list">Figure list</a></li>
+          <li><a href="#cd-filter">Filter</a></li>
+          <li><a href="#cd-form">Form</a></li>
+          <li><a href="#cd-grid">Grid</a></li>
+          <li><a href="#cd-hero">Hero</a></li>
+          <li><a href="#cd-image-grid">Image grid</a></li>
+          <li><a href="#cd-link-list">Link List</a></li>
+          <li><a href="#cd-page-title">Page title</a></li>
+          <li><a href="#cd-pagination">Pagination</a></li>
+          <li><a href="#cd-read-more">Read more</a></li>
+          <li><a href="#cd-search--inline">Search</a></li>
+          <li><a href="#cd-search--inline">Inline search</a></li>
+          <li><a href="#cd-social-links">Social links</a></li>
+          <li><a href="#cd-styled-list">Styled List</a></li>
+          <li><a href="#cd-table">Table</a></li>
+          <li><a href="#cd-tabs">Tabs</a></li>
+          <li><a href="#cd-tag">Tag</a></li>
+          <li><a href="#cd-teaser">Teaser</a></li>
+          <li><a href="#cd-title-list">Title List</a></li>
+          <li><a href="#cd-toc">Table of contents</a></li>
+          <li><a href="#cd-typography">Typography</a></li>
+        </ol>
+      </div>
+
+      {% include '@common_design_subtheme/../components/cds-color-picker/cds-color-picker.html.twig' %}
+
+      {{ page.content }}
+
+      {% if componentsModule %}
+
+        <h2 class="cd-styleguide cd-bleed--background-only"><a id="cd-components--content">Content components</a></h2>
+
+        <h3 class="cd-styleguide"><a id="cd-page-title">cd-page-title</a>
+          {% include '@cd-components/cd-back-to-toc/cd-back-to-toc.html.twig' %}</h3>
+
+        {% include '@cd-components/cd-page-title/cd-page-title.html.twig' %}
+
+        <h3 class="cd-styleguide"><a id="cd-banner">cd-banner</a>
+          {% include '@cd-components/cd-back-to-toc/cd-back-to-toc.html.twig' %}</h3>
+
+        {% include '@cd-components/cd-banner/cd-banner.html.twig' %}
+
+        <h3 class="cd-styleguide"><a id="cd-teaser">cd-teaser</a>
+          {% include '@cd-components/cd-back-to-toc/cd-back-to-toc.html.twig' %}</h3>
+
+        {% include '@cd-components/cd-teaser/cd-teaser.html.twig' %}
+
+        <h3 class="cd-styleguide"><a id="cd-bullet-list">cd-bullet-list</a>
+          {% include '@cd-components/cd-back-to-toc/cd-back-to-toc.html.twig' %}</h3>
+
+        {% include '@cd-components/cd-bullet-list/cd-bullet-list.html.twig' %}
+
+        <h3 class="cd-styleguide"><a id="cd-social-links">cd-social-links</a>
+          {% include '@cd-components/cd-back-to-toc/cd-back-to-toc.html.twig' %}</h3>
+
+        <div class="layout-wrapper" style="position: relative;width: auto; min-height:30px;">
+          {% include '@cd-components/cd-social-links/cd-social-links.html.twig' %}
+        </div>
+
+        <h3 class="cd-styleguide"><a id="cd-styled-list">cd-styled-list</a>
+          {% include '@cd-components/cd-back-to-toc/cd-back-to-toc.html.twig' %}</h3>
+
+        {% include '@cd-components/cd-styled-list/cd-styled-list.html.twig' %}
+
+        <h3 class="cd-styleguide"><a id="cd-link-list">cd-link-list</a>
+          {% include '@cd-components/cd-back-to-toc/cd-back-to-toc.html.twig' %}</h3>
+
+        {% include '@cd-components/cd-link-list/cd-link-list.html.twig' %}
+
+        <h3 class="cd-styleguide"><a id="cd-block-title">cd-block-title</a>
+          {% include '@cd-components/cd-back-to-toc/cd-back-to-toc.html.twig' %}</h3>
+
+        {% include '@cd-components/cd-block-title/cd-block-title.html.twig' %}
+
+        <h3 class="cd-styleguide"><a id="cd-title-list">cd-title-list</a>
+          {% include '@cd-components/cd-back-to-toc/cd-back-to-toc.html.twig' %}</h3>
+
+        {% include '@cd-components/cd-title-list/cd-title-list.html.twig' %}
+
+        <h3 class="cd-styleguide"><a id="cd-card">cd-card</a>
+          {% include '@cd-components/cd-back-to-toc/cd-back-to-toc.html.twig' %}</h3>
+
+        {% include '@cd-components/cd-card/cd-card.html.twig' %}
+
+        <h3 class="cd-styleguide"><a id="cd-event">cd-event</a>
+          {% include '@cd-components/cd-back-to-toc/cd-back-to-toc.html.twig' %}</h3>
+
+        {% include '@cd-components/cd-event/cd-event.html.twig' %}
+
+        <h3 class="cd-styleguide"><a id="cd-alert">cd-alert</a>
+          {% include '@cd-components/cd-back-to-toc/cd-back-to-toc.html.twig' %}</h3>
+
+        {% include '@cd-components/cd-alert/cd-alert.html.twig' %}
+
+        <h3 class="cd-styleguide"><a id="cd-table">cd-table</a>
+          {% include '@cd-components/cd-back-to-toc/cd-back-to-toc.html.twig' %}</h3>
+
+        {% include '@cd-components/cd-table/cd-table.html.twig' %}
+
+        <h3 class="cd-styleguide"><a id="cd-tag">cd-tag</a>
+          {% include '@cd-components/cd-back-to-toc/cd-back-to-toc.html.twig' %}</h3>
+
+        {% include '@cd-components/cd-tag/cd-tag.html.twig' %}
+
+        <h3 class="cd-styleguide"><a id="cd-author">cd-author</a>
+          {% include '@cd-components/cd-back-to-toc/cd-back-to-toc.html.twig' %}</h3>
+
+        {% include '@cd-components/cd-author/cd-author.html.twig' %}
+
+        <h3 class="cd-styleguide"><a id="cd-byline">cd-byline</a>
+          {% include '@cd-components/cd-back-to-toc/cd-back-to-toc.html.twig' %}</h3>
+
+        {% include '@cd-components/cd-byline/cd-byline.html.twig' %}
+
+        <h3 class="cd-styleguide"><a id="cd-toc">cd-toc</a>
+          {% include '@cd-components/cd-back-to-toc/cd-back-to-toc.html.twig' %}</h3>
+
+        {% include '@cd-components/cd-toc/cd-toc.html.twig' %}
+
+        <h2 class="cd-styleguide cd-bleed--background-only"><a id="cd-components--ui">UI components</a></h2>
+
+        <h3 class="cd-styleguide"><a id="cd-button">cd-button</a>
+          {% include '@cd-components/cd-back-to-toc/cd-back-to-toc.html.twig' %}</h3>
+
+        {% include '@cd-components/cd-button/cd-button.html.twig' %}
+
+        <h3 class="cd-styleguide"><a id="cd-read-more">cd-read-more</a>
+          {% include '@cd-components/cd-back-to-toc/cd-back-to-toc.html.twig' %}</h3>
+
+        {% include '@cd-components/cd-read-more/cd-read-more.html.twig' %}
+
+        <h3 class="cd-styleguide"><a id="cd-date">cd-date</a>
+          {% include '@cd-components/cd-back-to-toc/cd-back-to-toc.html.twig' %}</h3>
+
+        {% include '@cd-components/cd-date/cd-date.html.twig' %}
+        <p style="clear:both">{# clear #}</p>
+
+         <h3 class="cd-styleguide"><a id="cd-search">cd-search</a>
+          {% include '@cd-components/cd-back-to-toc/cd-back-to-toc.html.twig' %}</h3>
+
+          {% include '@cd-components/cd-search/cd-search.html.twig' %}
+
+        <h3 class="cd-styleguide"><a id="cd-search--inline">cd-search--inline</a>
+          {% include '@cd-components/cd-back-to-toc/cd-back-to-toc.html.twig' %}</h3>
+
+        <div style="position:relative">
+          {% include '@cd-components/cd-search--inline/cd-search--inline.html.twig' %}
+          <p style="clear:both">{# clear #}</p>
+        </div>
+
+        <h3 class="cd-styleguide"><a id="cd-pagination">cd-pagination</a>
+          {% include '@cd-components/cd-back-to-toc/cd-back-to-toc.html.twig' %}</h3>
+
+        {% include '@cd-components/cd-pagination/cd-pagination.html.twig' %}
+
+        <h3 class="cd-styleguide"><a id="cd-filter">cd-filter</a>
+          {% include '@cd-components/cd-back-to-toc/cd-back-to-toc.html.twig' %}</h3>
+        {# wrapper div needed for dropdown #}
+        <div>
+          {% include '@cd-components/cd-filter/cd-filter.html.twig' %}
+        </div>
+
+        <h3 class="cd-styleguide"><a id="cd-form">cd-form</a>
+          {% include '@cd-components/cd-back-to-toc/cd-back-to-toc.html.twig' %}</h3>
+
+        {% include '@cd-components/cd-form/cd-form.html.twig' %}
+
+        <h3 class="cd-styleguide"><a id="cd-tabs">cd-tabs</a>
+          {% include '@cd-components/cd-back-to-toc/cd-back-to-toc.html.twig' %}</h3>
+
+        {% include '@cd-components/cd-tabs/cd-tabs.html.twig' %}
+
+        <h2 class="cd-styleguide cd-bleed--background-only"><a id="cd-components--layout">Layout components</a></h2>
+
+        <h3 class="cd-styleguide"><a id="cd-grid">cd-grid</a>
+          {% include '@cd-components/cd-back-to-toc/cd-back-to-toc.html.twig' %}</h3>
+
+        {% include '@cd-components/cd-grid/cd-grid.html.twig' %}
+
+        <h3 class="cd-styleguide"><a id="cd-image-grid">cd-image-grid</a>
+          {% include '@cd-components/cd-back-to-toc/cd-back-to-toc.html.twig' %}</h3>
+
+        {% include '@cd-components/cd-image-grid/cd-image-grid.html.twig' %}
+
+        <h3 class="cd-styleguide"><a id="cd-figure-list">cd-figure-list</a>
+          {% include '@cd-components/cd-back-to-toc/cd-back-to-toc.html.twig' %}</h3>
+
+        {% include '@cd-components/cd-figure-list/cd-figure-list.html.twig' %}
+
+        <h3 class="cd-styleguide"><a id="cd-article">cd-article</a>
+          {% include '@cd-components/cd-back-to-toc/cd-back-to-toc.html.twig' %}</h3>
+
+        {% include '@cd-components/cd-article/cd-article.html.twig' %}
+
+        <h3 class="cd-styleguide"><a id="cd-typography">cd-typography</a>
+          {% include '@cd-components/cd-back-to-toc/cd-back-to-toc.html.twig' %}</h3>
+
+        {% include '@cd-components/cd-typography/cd-typography.html.twig' %}
+
+      {% endif %}
+
+    </div>{# /.layout-content #}
+
+  </main>
+
+  {% block footer_soft %}
+    {{ page.footer_soft }}
+  {% endblock %}
+
+  {% block footer %}
+    {% include '@common_design/cd/cd-footer/cd-footer.html.twig' %}
+  {% endblock %}
+
+
+</div>{# /.cd-layout-container #}

--- a/html/themes/custom/common_design_subtheme/templates/page--demo.html.twig
+++ b/html/themes/custom/common_design_subtheme/templates/page--demo.html.twig
@@ -49,7 +49,7 @@
   h3.cd-styleguide {
     display: block;
     padding: 1rem;
-    background-color: var(--cd-blue-grey);
+    background-color: var(--brand-grey);
   }
 
   h2.cd-styleguide {
@@ -61,7 +61,7 @@
     margin: 4rem 0;
     font-size: 2rem;
     width: 100%;
-    border: 1px solid var(--cd-blue--bright);
+    border: 1px solid var(--brand-primary--light);
     display: flex;
     justify-content: space-between;
     align-content: center;


### PR DESCRIPTION
# CD-386

Adds a floating color picker with a few arbitrary palettes to demonstrate the new `--brand` colors in all their dynamic DOM-based glory. A quick example:

https://user-images.githubusercontent.com/254753/165921240-beb729b0-49df-4912-99fb-3bb7ed0c6ad3.mov


