### PR TITLE
chore: remove cd prefix option because it is case sensitive

### DIFF
--- a/.github/workflows/docker-build-image.yml
+++ b/.github/workflows/docker-build-image.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - develop
-      - 'cd-*'
       - 'feature/**'
       - main
   release:


### PR DESCRIPTION
Branches should be named with capitalised ancronyms (the JIRA issue ID) so this does not pick up those branches.
For consistency with other repos, we can omit this completely and use feature/ prefix.

~~I encountered this as I was testing https://github.com/UN-OCHA/common_design/pull/327 (not directly related) because I wanted to deploy to the Feature site to run visual regression tests with Jenkins, but noticed the branch didn't come up as an option to deploy, because rupl correctly names branches with capitals.~~