### PR TITLE
Optional git commit message template

### DIFF
--- a/.gitconfig
+++ b/.gitconfig
@@ -1,0 +1,2 @@
+[commit]
+	template = .gitmessage

--- a/.gitmessage
+++ b/.gitmessage
@@ -1,0 +1,5 @@
+<type>[optional scope]: <description>
+
+[optional body]
+
+Refs: ID-123

--- a/.gitmessage
+++ b/.gitmessage
@@ -1,5 +1,9 @@
-<type>[optional scope]: <description>
+# <conventional-commit-type>(optional scope): <description>
+# https://www.conventionalcommits.org/en/v1.0.0
 
-[optional body]
+# Leave a blank line
 
-Refs: ID-123
+# [optional body]
+
+# Add Jira ticket IDs
+Refs:


### PR DESCRIPTION
The change to the git config has to be done manually by each user. This is a security feature.

Use the commit message template as a starting point, and adjust to fit your requirements.

### Per repo
To use the git config in this repo, from the directory root, run: `git config --local include.path .gitconfig`
This will add:
```
[include]
	path = ../.gitconfig
```
to the `.git/config` file. The `.gitconfig` file defines the commit message template to use.

### Globally
To use globally, add the `.gitmessage` file (to the home directory, in this case) and run: `git config --global commit.template ~/.gitmessage`