### PR TITLE
chore: update base theme to v7.2.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -145,7 +145,7 @@
         "drush/drush": "^10.1",
         "oomphinc/composer-installers-extender": "^2.0",
         "slevomat/coding-standard": "^7.0",
-        "unocha/common_design": "^7",
+        "unocha/common_design": "^7.2",
         "unocha/ocha_integrations": "^1.0",
         "unocha/ocha_media_content": "dev-main"
     },

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "3d0a95f0b1a8ae5421c8412f488e4207",
+    "content-hash": "1ad09db91743216fb2fb5d340e0fc6f3",
     "packages": [
         {
             "name": "asm89/stack-cors",
@@ -8460,16 +8460,16 @@
         },
         {
             "name": "unocha/common_design",
-            "version": "v7.0.1",
+            "version": "v7.2.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/UN-OCHA/common_design.git",
-                "reference": "b6b3a4f5c9b6360fa02155535de689b55d5983c2"
+                "reference": "3b3d0069d6132870b0dcb166ea2839b8ce5c7560"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/UN-OCHA/common_design/zipball/b6b3a4f5c9b6360fa02155535de689b55d5983c2",
-                "reference": "b6b3a4f5c9b6360fa02155535de689b55d5983c2",
+                "url": "https://api.github.com/repos/UN-OCHA/common_design/zipball/3b3d0069d6132870b0dcb166ea2839b8ce5c7560",
+                "reference": "3b3d0069d6132870b0dcb166ea2839b8ce5c7560",
                 "shasum": ""
             },
             "require": {
@@ -8483,9 +8483,9 @@
             "description": "OCHA Common Design base theme for Drupal 8",
             "support": {
                 "issues": "https://github.com/UN-OCHA/common_design/issues",
-                "source": "https://github.com/UN-OCHA/common_design/tree/v7.0.1"
+                "source": "https://github.com/UN-OCHA/common_design/tree/v7.2.0"
             },
-            "time": "2022-04-26T07:53:53+00:00"
+            "time": "2022-07-04T09:49:44+00:00"
         },
         {
             "name": "unocha/ocha_integrations",


### PR DESCRIPTION
Refs: CD-401

This will get the facets using `select_a11y` available for testing https://web.brand.unocha.org/facets