### PR TITLE
[CD-469] CD v8 plus sidebars

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -8323,16 +8323,16 @@
         },
         {
             "name": "unocha/common_design",
-            "version": "v8.0.2",
+            "version": "v8.1.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/UN-OCHA/common_design.git",
-                "reference": "2874981cc8587efbf1d419f8e6c4683867e1929c"
+                "reference": "2ea1deae46e659a313d9eebb2a838368f332b18f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/UN-OCHA/common_design/zipball/2874981cc8587efbf1d419f8e6c4683867e1929c",
-                "reference": "2874981cc8587efbf1d419f8e6c4683867e1929c",
+                "url": "https://api.github.com/repos/UN-OCHA/common_design/zipball/2ea1deae46e659a313d9eebb2a838368f332b18f",
+                "reference": "2ea1deae46e659a313d9eebb2a838368f332b18f",
                 "shasum": ""
             },
             "require": {
@@ -8347,9 +8347,9 @@
             "description": "OCHA Common Design base theme for Drupal 9+",
             "support": {
                 "issues": "https://github.com/UN-OCHA/common_design/issues",
-                "source": "https://github.com/UN-OCHA/common_design/tree/v8.0.2"
+                "source": "https://github.com/UN-OCHA/common_design/tree/v8.1.0"
             },
-            "time": "2023-04-12T20:35:54+00:00"
+            "time": "2023-05-04T09:44:30+00:00"
         },
         {
             "name": "unocha/ocha_integrations",

--- a/composer.lock
+++ b/composer.lock
@@ -8323,16 +8323,16 @@
         },
         {
             "name": "unocha/common_design",
-            "version": "v8.0.1",
+            "version": "v8.0.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/UN-OCHA/common_design.git",
-                "reference": "bb44eb7bf4f10b608c4a9ce2af269f03dd245e2d"
+                "reference": "2874981cc8587efbf1d419f8e6c4683867e1929c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/UN-OCHA/common_design/zipball/bb44eb7bf4f10b608c4a9ce2af269f03dd245e2d",
-                "reference": "bb44eb7bf4f10b608c4a9ce2af269f03dd245e2d",
+                "url": "https://api.github.com/repos/UN-OCHA/common_design/zipball/2874981cc8587efbf1d419f8e6c4683867e1929c",
+                "reference": "2874981cc8587efbf1d419f8e6c4683867e1929c",
                 "shasum": ""
             },
             "require": {
@@ -8347,9 +8347,9 @@
             "description": "OCHA Common Design base theme for Drupal 9+",
             "support": {
                 "issues": "https://github.com/UN-OCHA/common_design/issues",
-                "source": "https://github.com/UN-OCHA/common_design/tree/v8.0.1"
+                "source": "https://github.com/UN-OCHA/common_design/tree/v8.0.2"
             },
-            "time": "2023-03-22T20:34:28+00:00"
+            "time": "2023-04-12T20:35:54+00:00"
         },
         {
             "name": "unocha/ocha_integrations",
@@ -9240,5 +9240,5 @@
     "platform-overrides": {
         "php": "8.0"
     },
-    "plugin-api-version": "2.3.0"
+    "plugin-api-version": "2.2.0"
 }

--- a/config/block.block.common_design_subtheme_sidebarfirst.yml
+++ b/config/block.block.common_design_subtheme_sidebarfirst.yml
@@ -28,4 +28,4 @@ visibility:
     id: request_path
     negate: false
     context_mapping: {  }
-    pages: "/node/1\r\n/node/3\r\n/teaser-list"
+    pages: "/node/1\r\n/node/3\r\n/node/38\r\n/teaser-list"

--- a/config/block.block.common_design_subtheme_sidebarsecond.yml
+++ b/config/block.block.common_design_subtheme_sidebarsecond.yml
@@ -28,4 +28,4 @@ visibility:
     id: request_path
     negate: false
     context_mapping: {  }
-    pages: "/node/2\r\n/node/3"
+    pages: "/node/2\r\n/node/3\r\n/node/39"

--- a/config/core.menu.static_menu_link_overrides.yml
+++ b/config/core.menu.static_menu_link_overrides.yml
@@ -2,8 +2,14 @@ _core:
   default_config_hash: jdY7AU0tU-QsjmiOw3W8vwpYMb-By--_MSFgbqKUTYM
 definitions:
   user__page:
+    weight: -50
     menu_name: account
     parent: ''
-    weight: -10
     expanded: true
+    enabled: true
+  user__logout:
+    weight: -48
+    menu_name: account
+    parent: ''
+    expanded: false
     enabled: true

--- a/html/themes/custom/common_design_subtheme/templates/layout/page--node--38.html.twig
+++ b/html/themes/custom/common_design_subtheme/templates/layout/page--node--38.html.twig
@@ -1,0 +1,118 @@
+{#
+/**
+ * @file
+ * Theme override to display a single page.
+ *
+ * @overrides html/themes/contrib/common_design/templates/layout/page.html.twig
+ *
+ * The doctype, html, head and body tags are not in this template. Instead they
+ * can be found in the html.html.twig template in this directory.
+ *
+ * Available variables:
+ *
+ * General utility variables:
+ * - base_path: The base URL path of the Drupal installation. Will usually be
+ *   "/" unless you have installed Drupal in a sub-directory.
+ * - is_front: A flag indicating if the current page is the front page.
+ * - logged_in: A flag indicating if the user is registered and signed in.
+ * - is_admin: A flag indicating if the user has permission to access
+ *   administration pages.
+ *
+ * Site identity:
+ * - front_page: The URL of the front page. Use this instead of base_path when
+ *   linking to the front page. This includes the language domain or prefix.
+ *
+ * Page content (in order of occurrence in the default page.html.twig):
+ * - node: Fully loaded node, if there is an automatically-loaded node
+ *   associated with the page and the node ID is the second argument in the
+ *   page's path (e.g. node/12345 and node/12345/revisions, but not
+ *   comment/reply/12345).
+ *
+ * Regions:
+ * - page.header: Items for the header region.
+ * - page.primary_menu: Items for the primary menu region.
+ * - page.secondary_menu: Items for the secondary menu region.
+ * - page.highlighted: Items for the highlighted content region.
+ * - page.help: Dynamic help text, mostly for admin pages.
+ * - page.content: The main content of the current page.
+ * - page.sidebar_first: Items for the first sidebar.
+ * - page.sidebar_second: Items for the second sidebar.
+ * - page.footer: Items for the footer region.
+ * - page.breadcrumb: Items for the breadcrumb region.
+ *
+ * @see template_preprocess_page()
+ * @see html.html.twig
+ */
+#}
+
+{%
+  set layout_classes = [
+    'cd-container',
+  ]
+%}
+
+<div class="cd-page-layout-container">
+
+  {% block header %}
+    {% include '@common_design_subtheme/cd/cd-header/cd-header.html.twig' %}
+  {% endblock %}
+
+  {% if page.breadcrumb %}
+    {% block breadcrumb %}
+      <div class="cd-layout-breadcrumb cd-container">
+        {{ page.breadcrumb }}
+      </div>
+    {% endblock %}
+  {% endif %}
+
+  {% if page.highlighted %}
+    {% block highlighted %}
+      <div class="cd-layout-highlighted cd-container">
+        {{ page.highlighted }}
+      </div>
+    {% endblock %}
+  {% endif %}
+
+  {{ page.help }}
+
+  {% block main %}
+    {# Link to skip to the main content is in html.html.twig #}
+    <main role="main" {{ attributes.setAttribute('id', 'main-content').addClass(layout_classes) }}>
+
+      {{ page.page_title }}
+
+      <div class="cd-layout">
+
+        {% if page.sidebar_first %}
+          {#
+            We are using CSS pseudo class :empty to hide these aside elements if
+            the region prints empty. That means we cannot have any white space
+            between tags (as below).
+
+            NOTE: Enabling Twig debug means the div is no longer empty.
+            @see https://www.drupal.org/project/drupal/issues/953034
+          #}
+          <aside class="cd-layout__sidebar cd-layout__sidebar--first cd-content--compact" role="complementary">{{ page.sidebar_first }}</aside>
+        {% endif %}
+
+        <div class="cd-layout__content">
+          {{ page.content }}
+        </div>{# /.cd-layout__content #}
+
+        {% if page.sidebar_second %}
+          <aside class="cd-layout__sidebar cd-layout__sidebar--second cd-content--compact" role="complementary">{{ page.sidebar_second }}</aside>
+        {% endif %}
+      </div>
+
+    </main>
+  {% endblock %}
+
+  {% block footer_soft %}
+    {{ page.footer_soft }}
+  {% endblock %}
+
+  {% block footer %}
+    {% include '@common_design_subtheme/cd/cd-footer/cd-footer.html.twig' %}
+  {% endblock %}
+
+</div>{# /.cd-page-layout-container #}

--- a/html/themes/custom/common_design_subtheme/templates/layout/page--node--39.html.twig
+++ b/html/themes/custom/common_design_subtheme/templates/layout/page--node--39.html.twig
@@ -1,0 +1,118 @@
+{#
+/**
+ * @file
+ * Theme override to display a single page.
+ *
+ * @overrides html/themes/contrib/common_design/templates/layout/page.html.twig
+ *
+ * The doctype, html, head and body tags are not in this template. Instead they
+ * can be found in the html.html.twig template in this directory.
+ *
+ * Available variables:
+ *
+ * General utility variables:
+ * - base_path: The base URL path of the Drupal installation. Will usually be
+ *   "/" unless you have installed Drupal in a sub-directory.
+ * - is_front: A flag indicating if the current page is the front page.
+ * - logged_in: A flag indicating if the user is registered and signed in.
+ * - is_admin: A flag indicating if the user has permission to access
+ *   administration pages.
+ *
+ * Site identity:
+ * - front_page: The URL of the front page. Use this instead of base_path when
+ *   linking to the front page. This includes the language domain or prefix.
+ *
+ * Page content (in order of occurrence in the default page.html.twig):
+ * - node: Fully loaded node, if there is an automatically-loaded node
+ *   associated with the page and the node ID is the second argument in the
+ *   page's path (e.g. node/12345 and node/12345/revisions, but not
+ *   comment/reply/12345).
+ *
+ * Regions:
+ * - page.header: Items for the header region.
+ * - page.primary_menu: Items for the primary menu region.
+ * - page.secondary_menu: Items for the secondary menu region.
+ * - page.highlighted: Items for the highlighted content region.
+ * - page.help: Dynamic help text, mostly for admin pages.
+ * - page.content: The main content of the current page.
+ * - page.sidebar_first: Items for the first sidebar.
+ * - page.sidebar_second: Items for the second sidebar.
+ * - page.footer: Items for the footer region.
+ * - page.breadcrumb: Items for the breadcrumb region.
+ *
+ * @see template_preprocess_page()
+ * @see html.html.twig
+ */
+#}
+
+{%
+  set layout_classes = [
+    'cd-container',
+  ]
+%}
+
+<div class="cd-page-layout-container">
+
+  {% block header %}
+    {% include '@common_design_subtheme/cd/cd-header/cd-header.html.twig' %}
+  {% endblock %}
+
+  {% if page.breadcrumb %}
+    {% block breadcrumb %}
+      <div class="cd-layout-breadcrumb cd-container">
+        {{ page.breadcrumb }}
+      </div>
+    {% endblock %}
+  {% endif %}
+
+  {% if page.highlighted %}
+    {% block highlighted %}
+      <div class="cd-layout-highlighted cd-container">
+        {{ page.highlighted }}
+      </div>
+    {% endblock %}
+  {% endif %}
+
+  {{ page.help }}
+
+  {% block main %}
+    {# Link to skip to the main content is in html.html.twig #}
+    <main role="main" {{ attributes.setAttribute('id', 'main-content').addClass(layout_classes) }}>
+
+      {{ page.page_title }}
+
+      <div class="cd-layout">
+
+        {% if page.sidebar_first %}
+          {#
+            We are using CSS pseudo class :empty to hide these aside elements if
+            the region prints empty. That means we cannot have any white space
+            between tags (as below).
+
+            NOTE: Enabling Twig debug means the div is no longer empty.
+            @see https://www.drupal.org/project/drupal/issues/953034
+          #}
+          <aside class="cd-layout__sidebar cd-layout__sidebar--first cd-content--compact" role="complementary">{{ page.sidebar_first }}</aside>
+        {% endif %}
+
+        <div class="cd-layout__content">
+          {{ page.content }}
+        </div>{# /.cd-layout__content #}
+
+        {% if page.sidebar_second %}
+          <aside class="cd-layout__sidebar cd-layout__sidebar--second cd-content--compact" role="complementary">{{ page.sidebar_second }}</aside>
+        {% endif %}
+      </div>
+
+    </main>
+  {% endblock %}
+
+  {% block footer_soft %}
+    {{ page.footer_soft }}
+  {% endblock %}
+
+  {% block footer %}
+    {% include '@common_design_subtheme/cd/cd-footer/cd-footer.html.twig' %}
+  {% endblock %}
+
+</div>{# /.cd-page-layout-container #}


### PR DESCRIPTION
# CD-469

Upgrades CD to yesterday's release and adds the necessary templates for our new sidebar examples. The nav will need some adjusting to accommodate the four pages:

- Sidebar first: `node/1` (no change)
- Sidebar second: `node/2` (no change)
- Compact first: `node/38`
- Compact second: `node/39`
- Sidebar both: Remove from menu but don't delete the page. The config for `node/3` remains in the sidebars so we can pull it up if needed, but we don't want to advertise this configuration anymore)