### PR TITLE
fix: flip the template sidebar logic so compact is default on CD Demo

### DIFF
--- a/html/themes/custom/common_design_subtheme/templates/layout/page--node--38.html.twig
+++ b/html/themes/custom/common_design_subtheme/templates/layout/page--node--38.html.twig
@@ -92,7 +92,7 @@
             NOTE: Enabling Twig debug means the div is no longer empty.
             @see https://www.drupal.org/project/drupal/issues/953034
           #}
-          <aside class="cd-layout__sidebar cd-layout__sidebar--first cd-content--compact" role="complementary">{{ page.sidebar_first }}</aside>
+          <aside class="cd-layout__sidebar cd-layout__sidebar--first cd-layout__sidebar--wide" role="complementary">{{ page.sidebar_first }}</aside>
         {% endif %}
 
         <div class="cd-layout__content">
@@ -100,7 +100,7 @@
         </div>{# /.cd-layout__content #}
 
         {% if page.sidebar_second %}
-          <aside class="cd-layout__sidebar cd-layout__sidebar--second cd-content--compact" role="complementary">{{ page.sidebar_second }}</aside>
+          <aside class="cd-layout__sidebar cd-layout__sidebar--second cd-layout__sidebar--wide" role="complementary">{{ page.sidebar_second }}</aside>
         {% endif %}
       </div>
 

--- a/html/themes/custom/common_design_subtheme/templates/layout/page--node--39.html.twig
+++ b/html/themes/custom/common_design_subtheme/templates/layout/page--node--39.html.twig
@@ -92,7 +92,7 @@
             NOTE: Enabling Twig debug means the div is no longer empty.
             @see https://www.drupal.org/project/drupal/issues/953034
           #}
-          <aside class="cd-layout__sidebar cd-layout__sidebar--first cd-content--compact" role="complementary">{{ page.sidebar_first }}</aside>
+          <aside class="cd-layout__sidebar cd-layout__sidebar--first cd-layout__sidebar--wide" role="complementary">{{ page.sidebar_first }}</aside>
         {% endif %}
 
         <div class="cd-layout__content">
@@ -100,7 +100,7 @@
         </div>{# /.cd-layout__content #}
 
         {% if page.sidebar_second %}
-          <aside class="cd-layout__sidebar cd-layout__sidebar--second cd-content--compact" role="complementary">{{ page.sidebar_second }}</aside>
+          <aside class="cd-layout__sidebar cd-layout__sidebar--second cd-layout__sidebar--wide" role="complementary">{{ page.sidebar_second }}</aside>
         {% endif %}
       </div>
 

--- a/html/themes/custom/common_design_subtheme/templates/layout/page.html.twig
+++ b/html/themes/custom/common_design_subtheme/templates/layout/page.html.twig
@@ -1,11 +1,118 @@
-{% embed '@common_design/layout/page.html.twig' %}
+{#
+/**
+ * @file
+ * Theme override to display a single page.
+ *
+ * @overrides html/themes/contrib/common_design/templates/layout/page.html.twig
+ *
+ * The doctype, html, head and body tags are not in this template. Instead they
+ * can be found in the html.html.twig template in this directory.
+ *
+ * Available variables:
+ *
+ * General utility variables:
+ * - base_path: The base URL path of the Drupal installation. Will usually be
+ *   "/" unless you have installed Drupal in a sub-directory.
+ * - is_front: A flag indicating if the current page is the front page.
+ * - logged_in: A flag indicating if the user is registered and signed in.
+ * - is_admin: A flag indicating if the user has permission to access
+ *   administration pages.
+ *
+ * Site identity:
+ * - front_page: The URL of the front page. Use this instead of base_path when
+ *   linking to the front page. This includes the language domain or prefix.
+ *
+ * Page content (in order of occurrence in the default page.html.twig):
+ * - node: Fully loaded node, if there is an automatically-loaded node
+ *   associated with the page and the node ID is the second argument in the
+ *   page's path (e.g. node/12345 and node/12345/revisions, but not
+ *   comment/reply/12345).
+ *
+ * Regions:
+ * - page.header: Items for the header region.
+ * - page.primary_menu: Items for the primary menu region.
+ * - page.secondary_menu: Items for the secondary menu region.
+ * - page.highlighted: Items for the highlighted content region.
+ * - page.help: Dynamic help text, mostly for admin pages.
+ * - page.content: The main content of the current page.
+ * - page.sidebar_first: Items for the first sidebar.
+ * - page.sidebar_second: Items for the second sidebar.
+ * - page.footer: Items for the footer region.
+ * - page.breadcrumb: Items for the breadcrumb region.
+ *
+ * @see template_preprocess_page()
+ * @see html.html.twig
+ */
+#}
+
+{%
+  set layout_classes = [
+    'cd-container',
+  ]
+%}
+
+<div class="cd-page-layout-container">
 
   {% block header %}
     {% include '@common_design_subtheme/cd/cd-header/cd-header.html.twig' %}
+  {% endblock %}
+
+  {% if page.breadcrumb %}
+    {% block breadcrumb %}
+      <div class="cd-layout-breadcrumb cd-container">
+        {{ page.breadcrumb }}
+      </div>
+    {% endblock %}
+  {% endif %}
+
+  {% if page.highlighted %}
+    {% block highlighted %}
+      <div class="cd-layout-highlighted cd-container">
+        {{ page.highlighted }}
+      </div>
+    {% endblock %}
+  {% endif %}
+
+  {{ page.help }}
+
+  {% block main %}
+    {# Link to skip to the main content is in html.html.twig #}
+    <main role="main" {{ attributes.setAttribute('id', 'main-content').addClass(layout_classes) }}>
+
+      {{ page.page_title }}
+
+      <div class="cd-layout">
+
+        {% if page.sidebar_first %}
+          {#
+            We are using CSS pseudo class :empty to hide these aside elements if
+            the region prints empty. That means we cannot have any white space
+            between tags (as below).
+
+            NOTE: Enabling Twig debug means the div is no longer empty.
+            @see https://www.drupal.org/project/drupal/issues/953034
+          #}
+          <aside class="cd-layout__sidebar cd-layout__sidebar--first cd-content--compact" role="complementary">{{ page.sidebar_first }}</aside>
+        {% endif %}
+
+        <div class="cd-layout__content">
+          {{ page.content }}
+        </div>{# /.cd-layout__content #}
+
+        {% if page.sidebar_second %}
+          <aside class="cd-layout__sidebar cd-layout__sidebar--second cd-content--compact" role="complementary">{{ page.sidebar_second }}</aside>
+        {% endif %}
+      </div>
+
+    </main>
+  {% endblock %}
+
+  {% block footer_soft %}
+    {{ page.footer_soft }}
   {% endblock %}
 
   {% block footer %}
     {% include '@common_design_subtheme/cd/cd-footer/cd-footer.html.twig' %}
   {% endblock %}
 
-{% endembed %}
+</div>{# /.cd-page-layout-container #}


### PR DESCRIPTION
This is to match the new WP support demo and also seems to be our general trend of offering more compact sidebars by default, but having the wider option available if people decide to use it.

Refs: CD-469