### PR TITLE
chore: switch ckeditor version

### DIFF
--- a/PATCHES/ckeditor_version_dependency.patch
+++ b/PATCHES/ckeditor_version_dependency.patch
@@ -1,3 +1,32 @@
+diff --git a/README.md b/README.md
+index 16bcf61..abf0e46 100644
+--- a/README.md
++++ b/README.md
+@@ -2,7 +2,7 @@ # Common OCHA Media Content for Drupal.
+ 
+ ## Core Modules
+   - breakpoint
+-  - ckeditor
++  - ckeditor5
+   - media
+   - media_library
+   - responsive_image
+diff --git a/config/optional/editor.editor.full_html.yml b/config/optional/editor.editor.full_html.yml
+index f59d2b1..64a4d3c 100644
+--- a/config/optional/editor.editor.full_html.yml
++++ b/config/optional/editor.editor.full_html.yml
+@@ -4,9 +4,9 @@ dependencies:
+   config:
+     - filter.format.full_html
+   module:
+-    - ckeditor
++    - ckeditor5
+ format: full_html
+-editor: ckeditor
++editor: ckeditor5
+ settings:
+   toolbar:
+     rows:
 diff --git a/ocha_media_content.info.yml b/ocha_media_content.info.yml
 index f45db52..61bfb98 100644
 --- a/ocha_media_content.info.yml

--- a/PATCHES/ckeditor_version_dependency.patch
+++ b/PATCHES/ckeditor_version_dependency.patch
@@ -1,5 +1,5 @@
 diff --git a/ocha_media_content.info.yml b/ocha_media_content.info.yml
-index 4c278c8..2597320 100644
+index f45db52..61bfb98 100644
 --- a/ocha_media_content.info.yml
 +++ b/ocha_media_content.info.yml
 @@ -8,7 +8,7 @@ core_version_requirement: ^8 || ^9
@@ -9,14 +9,14 @@ index 4c278c8..2597320 100644
 -  - ckeditor
 +  - ckeditor5
    - editor
-   - fitvids
    - media
-@@ -20,7 +20,7 @@ install:
+   - media_library
+@@ -19,7 +19,7 @@ install:
  # Note that any dependencies of the modules listed here will be installed automatically.
  dependencies:
    - breakpoint
 -  - ckeditor
 +  - ckeditor5
-   - fitvids
    - media
    - media_library
+   - responsive_image

--- a/PATCHES/ckeditor_version_dependency.patch
+++ b/PATCHES/ckeditor_version_dependency.patch
@@ -1,0 +1,22 @@
+diff --git a/ocha_media_content.info.yml b/ocha_media_content.info.yml
+index 4c278c8..2597320 100644
+--- a/ocha_media_content.info.yml
++++ b/ocha_media_content.info.yml
+@@ -8,7 +8,7 @@ core_version_requirement: ^8 || ^9
+ # Modules to install.
+ install:
+   - breakpoint
+-  - ckeditor
++  - ckeditor5
+   - editor
+   - fitvids
+   - media
+@@ -20,7 +20,7 @@ install:
+ # Note that any dependencies of the modules listed here will be installed automatically.
+ dependencies:
+   - breakpoint
+-  - ckeditor
++  - ckeditor5
+   - fitvids
+   - media
+   - media_library

--- a/composer.patches.json
+++ b/composer.patches.json
@@ -13,6 +13,9 @@
         },
         "drupal/username_enumeration_prevention": {
             "Avoid leaking the path via Drupal.settings json": "PATCHES/username_enumeration_prevention-user-login-block-form-3312288.patch"
+        },
+        "unocha/ocha_media_content": {
+            "Change version of ckeditor dependency": "PATCHES/ckeditor_version_dependency.patch"
         }
     }
 }

--- a/config/core.extension.yml
+++ b/config/core.extension.yml
@@ -6,7 +6,7 @@ module:
   block: 0
   block_content: 0
   breakpoint: 0
-  ckeditor: 0
+  ckeditor5: 0
   components: 0
   config: 0
   config_split: 0

--- a/config/editor.editor.full_html.yml
+++ b/config/editor.editor.full_html.yml
@@ -1,58 +1,78 @@
-uuid: 6065b89a-9840-47f2-93de-7523a0a4448e
+uuid: 2b81a513-3804-4544-908d-45b5fd919db2
 langcode: en
 status: true
 dependencies:
   config:
     - filter.format.full_html
   module:
-    - ckeditor
+    - ckeditor5
 format: full_html
-editor: ckeditor
+editor: ckeditor5
 settings:
   toolbar:
-    rows:
-      -
-        -
-          name: Formatting
-          items:
-            - Bold
-            - Italic
-        -
-          name: Links
-          items:
-            - DrupalLink
-            - DrupalUnlink
-        -
-          name: Lists
-          items:
-            - BulletedList
-            - NumberedList
-            - Blockquote
-        -
-          name: Align
-          items:
-            - JustifyLeft
-            - JustifyCenter
-            - JustifyRight
-        -
-          name: Media
-          items:
-            - DrupalMediaLibrary
-            - DrupalImage
-        -
-          name: Format
-          items:
-            - Format
-        -
-          name: Tools
-          items:
-            - Source
-  plugins: {  }
+    items:
+      - bold
+      - italic
+      - '|'
+      - link
+      - '|'
+      - bulletedList
+      - numberedList
+      - blockQuote
+      - '|'
+      - alignment
+      - '|'
+      - drupalMedia
+      - drupalInsertImage
+      - '|'
+      - heading
+      - '|'
+      - sourceEditing
+      - '|'
+      - code
+  plugins:
+    ckeditor5_heading:
+      enabled_headings:
+        - heading2
+        - heading3
+        - heading4
+        - heading5
+        - heading6
+    ckeditor5_sourceEditing:
+      allowed_tags:
+        - '<cite>'
+        - '<dl>'
+        - '<dt>'
+        - '<dd>'
+        - '<a hreflang>'
+        - '<blockquote cite>'
+        - '<ul type>'
+        - '<ol type>'
+        - '<h2 id>'
+        - '<h3 id>'
+        - '<h4 id>'
+        - '<h5 id>'
+        - '<h6 id>'
+        - '<img data-entity-type data-entity-uuid data-image-style>'
+        - '<drupal-media title>'
+    ckeditor5_list:
+      reversed: false
+      startIndex: true
+    ckeditor5_alignment:
+      enabled_alignments:
+        - left
+        - center
+        - right
+        - justify
+    ckeditor5_imageResize:
+      allow_resize: true
+    media_media:
+      allow_view_mode_override: true
 image_upload:
   status: false
   scheme: public
   directory: inline-images
   max_size: ''
   max_dimensions:
-    width: null
-    height: null
+    width: 0
+    height: 0

--- a/config/filter.format.full_html.yml
+++ b/config/filter.format.full_html.yml
@@ -31,7 +31,7 @@ filters:
     status: true
     weight: -50
     settings:
-      allowed_html: '<a href hreflang> <em> <strong> <cite> <blockquote cite> <code> <ul type> <ol type start> <li> <dl> <dt> <dd> <h2 id> <h3 id> <h4 id> <h5 id> <h6 id> <img src alt data-entity-type data-entity-uuid data-align data-caption data-image-style> <drupal-media data-entity-type data-entity-uuid data-view-mode data-align data-caption alt title> <p>'
+      allowed_html: '<br> <p class="text-align-left text-align-center text-align-right text-align-justify"> <h2 id class="text-align-left text-align-center text-align-right text-align-justify"> <h3 id class="text-align-left text-align-center text-align-right text-align-justify"> <h4 id class="text-align-left text-align-center text-align-right text-align-justify"> <h5 id class="text-align-left text-align-center text-align-right text-align-justify"> <h6 id class="text-align-left text-align-center text-align-right text-align-justify"> <cite> <dl> <dt> <dd> <a hreflang href> <blockquote cite> <ul type> <ol type start> <img data-entity-type data-entity-uuid data-image-style src alt height width data-caption data-align> <drupal-media title data-entity-type data-entity-uuid alt data-view-mode data-caption data-align> <strong> <em> <code> <li>'
       filter_html_help: true
       filter_html_nofollow: false
   media_embed:


### PR DESCRIPTION
Refs: OPS-9268

Comes with an Internet Explorer warning which has, thankfully, lost its bite:
![image](https://github.com/UN-OCHA/common-design-site/assets/67453/75377f79-9e57-4118-84dd-df0d23fa76f7)

It also changes a lot of tags by default, presumably these aren't a problem for this site but might need a closer review for other sites.