### PR TITLE
chore: remove problematic config

### DIFF
--- a/config/filter.format.full_html.yml
+++ b/config/filter.format.full_html.yml
@@ -84,10 +84,3 @@ filters:
     status: true
     weight: -44
     settings: {  }
-  filter_image_style:
-    id: filter_image_style
-    provider: image
-    status: true
-    weight: -43
-    settings:
-      allowed_styles: {  }


### PR DESCRIPTION
Refs: CD-497

This is a workaround to see if it helps the D10 deployment - updb happens before the config change, which breaks the deployment.

Another discussion is whether we want to remove the 'filter_image_style'.