### PR TITLE
chore: add social_auth scope to config

### DIFF
--- a/config/social_auth_hid.settings.yml
+++ b/config/social_auth_hid.settings.yml
@@ -8,3 +8,7 @@ disable_default: true
 disable_password_fields: true
 disable_email_field: true
 disable_user_field: true
+disable_user_create: false
+maintenance_access: false
+scopes: profile
+endpoints: ''


### PR DESCRIPTION
Refs: CD-516

For other sites moving to social_auth v4, this config should come in an update hook https://www.drupal.org/project/social_auth_hid/issues/3402163 . For CD, this is to make sure the configuration survives new deploys.