### PR TITLE
OPS-9885 Base theme update

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -70,7 +70,7 @@
         "drush/drush": "^12",
         "oomphinc/composer-installers-extender": "^2.0",
         "orakili/composer-drupal-info-file-patch-helper": "^1",
-        "unocha/common_design": "^9.2",
+        "unocha/common_design": "^9",
         "unocha/ocha_integrations": "^2",
         "unocha/ocha_media_content": "dev-main",
         "unocha/ocha_monitoring": "^1.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "af890d76f087c82b080b4b0dfca5d398",
+    "content-hash": "eacf78f0c187ed5e8fd58e030fde1da0",
     "packages": [
         {
             "name": "asm89/stack-cors",
@@ -14623,16 +14623,16 @@
         },
         {
             "name": "unocha/common_design",
-            "version": "v9.3.0",
+            "version": "v9.3.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/UN-OCHA/common_design.git",
-                "reference": "5d5bba22242b2ac19716d45f4f385b9c9b2d020d"
+                "reference": "eb280c1e3293f3a84ee443a10099f83446081cd2"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/UN-OCHA/common_design/zipball/5d5bba22242b2ac19716d45f4f385b9c9b2d020d",
-                "reference": "5d5bba22242b2ac19716d45f4f385b9c9b2d020d",
+                "url": "https://api.github.com/repos/UN-OCHA/common_design/zipball/eb280c1e3293f3a84ee443a10099f83446081cd2",
+                "reference": "eb280c1e3293f3a84ee443a10099f83446081cd2",
                 "shasum": ""
             },
             "require": {
@@ -14647,9 +14647,9 @@
             "description": "OCHA Common Design base theme for Drupal 9+",
             "support": {
                 "issues": "https://github.com/UN-OCHA/common_design/issues",
-                "source": "https://github.com/UN-OCHA/common_design/tree/v9.3.0"
+                "source": "https://github.com/UN-OCHA/common_design/tree/v9.3.1"
             },
-            "time": "2024-01-04T12:36:24+00:00"
+            "time": "2024-01-17T09:30:38+00:00"
         },
         {
             "name": "unocha/ocha_integrations",


### PR DESCRIPTION
chore: update base theme to latest
https://github.com/UN-OCHA/common_design/releases/tag/v9.3.1
Avails of fixes for CLS in OCHA Services and correct path for select_a11y widget so Facets in sidebar on Views lists work on demo site.

Refs: OPS-9885