### PR TITLE
Deploy 22-10-2024

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@
 All notable changes to this project will be documented in this file.
 <!--- END HEADER -->
 
+## [1.5.8](https://github.com/UN-OCHA/common-design-site/compare/v1.5.7...v1.5.8) (2024-10-21)
+
+### Chores
+
+* Update all outdated drupal/* unocha/* drush/* packages. ([57322e](https://github.com/UN-OCHA/common-design-site/commit/57322effbc8ec90f4d9e87eece9b4e35ca39b815))
+
 ## [1.5.7](https://github.com/UN-OCHA/common-design-site/compare/v1.5.6...v1.5.7) (2024-10-15)
 
 ### Chores

--- a/composer.json
+++ b/composer.json
@@ -241,5 +241,5 @@
             "@git-hooks"
         ]
     },
-    "version": "1.5.7"
+    "version": "1.5.8"
 }

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "c55433baf2a2d5750f2c5d9c89bf0a84",
+    "content-hash": "dde4dddca622baa7d0ee310e4cf7be82",
     "packages": [
         {
             "name": "asm89/stack-cors",


### PR DESCRIPTION
## [1.5.8](https://github.com/UN-OCHA/common-design-site/compare/v1.5.7...v1.5.8) (2024-10-21)

### Chores

* Update all outdated drupal/* unocha/* drush/* packages. ([57322e](https://github.com/UN-OCHA/common-design-site/commit/57322effbc8ec90f4d9e87eece9b4e35ca39b815))

## Composer changes

| Production Changes    | From    | To      | Compare                                                                 |
|-----------------------|---------|---------|-------------------------------------------------------------------------|
| aws/aws-sdk-php       | 3.323.4 | 3.324.4 | [...](https://github.com/aws/aws-sdk-php/compare/3.323.4...3.324.4)     |
| open-telemetry/api    | 1.1.0   | 1.1.1   | [...](https://github.com/opentelemetry-php/api/compare/1.1.0...1.1.1)   |
| open-telemetry/sdk    | 1.1.0   | 1.1.1   | [...](https://github.com/opentelemetry-php/sdk/compare/1.1.0...1.1.1)   |
| phpstan/phpdoc-parser | 1.32.0  | 1.33.0  | [...](https://github.com/phpstan/phpdoc-parser/compare/1.32.0...1.33.0) |

