### PR TITLE
chore: Use the latest mysql:11 docker image for tests.

### DIFF
--- a/tests/docker-compose.yml
+++ b/tests/docker-compose.yml
@@ -10,7 +10,7 @@ volumes:
 
 services:
   mysql:
-    image: public.ecr.aws/unocha/mysql:11.4
+    image: public.ecr.aws/unocha/mysql:11
     hostname: common-design-test-mysql
     container_name: common-design-test-mysql
     environment:


### PR DESCRIPTION
This is now MariaDB 11.8.6, which matches RDS dev.

Refs: OPS-12081